### PR TITLE
Add XMP sidecar support

### DIFF
--- a/geotag/location_history.py
+++ b/geotag/location_history.py
@@ -13,7 +13,6 @@ class Location:
     timestamp: int
     latitude: float
     longitude: float
-    accuracy: int
 
     @staticmethod
     def from_google_json(d: dict) -> Location:
@@ -21,7 +20,6 @@ class Location:
             timestamp=int(d["timestampMs"]) // 1000,
             latitude=int(d["latitudeE7"]) / 10 ** 7,
             longitude=int(d["longitudeE7"]) / 10 ** 7,
-            accuracy=int(d["accuracy"]),
         )
 
 

--- a/geotag/main.py
+++ b/geotag/main.py
@@ -3,25 +3,37 @@ import json
 import os
 import tempfile
 
-from .exif import get_exif_diff, read_exif, write_exif, parse_exif_timezone_offset
+from .exif import (
+    get_exif_diff,
+    merge_sidecar_exif,
+    parse_exif_timezone_offset,
+    read_exif,
+    write_exif,
+)
 from .location_history import discard_bad_gps_points, read_google_location_history
 from .log import log
 
 
 def add_google_location_to_images(
-    location_history_path: str, root_path: str, utc_offset: str
+    location_history_path: str, root_path: str, utc_offset: str, use_sidecar: bool
 ):
     location_history = read_google_location_history(location_history_path)
     location_history = discard_bad_gps_points(location_history)
-    timestamps = [loc.timestamp for loc in location_history]
-    exif = read_exif(root_path)
-    exif_diff = get_exif_diff(exif, location_history, utc_offset)
+    all_exif = read_exif(root_path)
+    exif = merge_sidecar_exif(all_exif)
+    exif_diff = get_exif_diff(exif, location_history, utc_offset, use_sidecar)
     with tempfile.TemporaryDirectory() as temp_directory:
         exif_diff_path = os.path.join(temp_directory, "exif_diff.json")
         log.debug(f"writing temporary exif diff json to {exif_diff_path}...")
         with open(exif_diff_path, "w") as f:
             json.dump(exif_diff, f)
-        write_exif(root_path, exif_diff_path)
+        if use_sidecar:
+            # The "source_file" (now destination file) may not yet exist
+            # so we need to write each file individually.
+            for source_file in [diff["SourceFile"] for diff in exif_diff]:
+                write_exif(source_file, exif_diff_path)
+        else:
+            write_exif(root_path, exif_diff_path)
 
 
 def main():
@@ -30,7 +42,8 @@ def main():
         description="Add GPS metadata to your photos/videos using your Google location history data",
     )
     parser.add_argument(
-        "location_history", help="path to your google location history json dump",
+        "location_history",
+        help="path to your google location history json dump",
     )
     parser.add_argument(
         "root_path", help="path to the photos you want to add GPS info to"
@@ -42,9 +55,15 @@ def main():
         '(default value: "+00:00")',
         default="+00:00",
     )
+    parser.add_argument(
+        "--use-sidecar",
+        help="include XMP sidecar files when reading metadata, "
+        "write GPS metadata to XMP sidecar instead of writing to the image file",
+        action="store_true",
+    )
     args = parser.parse_args()
 
     utc_offset_default = parse_exif_timezone_offset(args.utc_offset_default)
     add_google_location_to_images(
-        args.location_history, args.root_path, utc_offset_default
+        args.location_history, args.root_path, utc_offset_default, args.use_sidecar
     )


### PR DESCRIPTION
When the user adds --use-sidecar, geotag will 
1. read merge metadata from XMP sidecar files when reading metadata. Metadata in XMP sidecar is prioritized over metadata in the image file.
2. write metadata to XMP sidecar (basename.xmp)

Some isort, black and flake8 formatting changes were also included.